### PR TITLE
inttest: make dut more robust

### DIFF
--- a/Dockerfile.inttest
+++ b/Dockerfile.inttest
@@ -1,7 +1,12 @@
 FROM docker.io/library/golang:1.19-alpine
 
+# required for wait-for-hello.sh script
+RUN apk add \
+    openssh \
+    sshpass \
+    perl-xml-xpath 
+
 COPY . /src
 
 WORKDIR /src/inttest
-
-ENTRYPOINT CGO_ENABLED=0 go test -v .
+CMD CGO_ENABLED=0 go test -v .

--- a/inttest/Dockerfile.csrx
+++ b/inttest/Dockerfile.csrx
@@ -1,7 +1,0 @@
-ARG CSRX_IMAGE
-FROM $CSRX_IMAGE
-
-# Remove settings the core_pattern to allow to work in rootless podman
-RUN sed -i '/\/proc\/sys\/kernel\/core_pattern/d' /etc/rc.local
-
-COPY csrx.conf /config/juniper.conf

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -1,11 +1,12 @@
 .PHONY: all inttest inttest-csrx
 
-all: inttest 
+.DEFAULT: inttest 
 
 inttest: inttest-csrx
 
 inttest-csrx:
 	docker-compose -f docker-compose.csrx.yml up \
+		--build \
 		--remove-orphans \
 		--abort-on-container-exit \
 		--exit-code-from inttest

--- a/inttest/docker-compose.csrx.yml
+++ b/inttest/docker-compose.csrx.yml
@@ -5,18 +5,25 @@ services:
       context: ..
       dockerfile: Dockerfile.inttest
     environment:
-      - NETCONF_DUT_SSHADDR=dut:22
-      - NETCONF_DUT_SSHUSER=root
-      - NETCONF_DUT_SSHPASS=juniper123
+      NETCONF_DUT_SSHHOST: csrx
+      NETCONF_DUT_SSHPORT: 22
+      NETCONF_DUT_SSHADDR: csrx:22
+      NETCONF_DUT_SSHUSER: root
+      NETCONF_DUT_SSHPASS: juniper123
+      NETCONF_DUT_FLAVOR: junos
     depends_on:
-      dut:
-        condition: service_healthy
-  dut:
-    image: ghcr.io/nemith/netconf_dut_juniper_csrx:20.3R1.8
+      - csrx
+    command: >
+      sh -c "./wait-for-hello.sh
+      -s $$NETCONF_DUT_SSHPASS
+      -p $$NETCONF_DUT_SSHPORT
+      $$NETCONF_DUT_SSHUSER@$$NETCONF_DUT_SSHHOST &&
+      CGO_ENABLED=0 go test -v ."
+  csrx:
+    image: ${CSRX_IMAGE:-ghcr.io/nemith/netconf_dut_juniper_csrx:20.3R1.8}
+    environment:
+      - CSRX_JUNOS_CONFIG=/root/initial.conf
     privileged: true
-    healthcheck:
-      test: nc -z localhost 22
-      interval: 10s
-      retries: 5
-      timeout: 5s
     stop_signal: SIGTERM
+    volumes:
+      - ./csrx.conf:/root/initial.conf:ro

--- a/inttest/ssh_test.go
+++ b/inttest/ssh_test.go
@@ -2,6 +2,7 @@ package inttest
 
 import (
 	"context"
+	"net"
 	"os"
 	"testing"
 
@@ -33,9 +34,14 @@ func sshAuth(t *testing.T) ssh.AuthMethod {
 }
 
 func TestSSHConnect(t *testing.T) {
-	addr := os.Getenv("NETCONF_DUT_SSHADDR")
-	if addr == "" {
-		t.Skip("NETCONF_DUT_SSHADDR not set, skipping test")
+	host := os.Getenv("NETCONF_DUT_SSHHOST")
+	if host == "" {
+		t.Skip("NETCONF_DUT_SSHHOST not set, skipping test")
+	}
+
+	port := os.Getenv("NETCONF_DUT_SSHPORT")
+	if port == "" {
+		port = "22"
 	}
 
 	user := os.Getenv("NETCONF_DUT_SSHUSER")
@@ -49,6 +55,7 @@ func TestSSHConnect(t *testing.T) {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
+	addr := net.JoinHostPort(host, port)
 	t.Logf("connecting to %s", addr)
 
 	ctx := context.Background()

--- a/inttest/wait-for-hello.sh
+++ b/inttest/wait-for-hello.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+usage() {
+    printf "Usage: %s [-p <port>] [-s <pass>] [-t <timeout>] [-w <wait>] [<username>@]<host>\n" "$0" >&2
+    printf "\n" >&2
+    printf "SSH_PASS enviroment variable can be used in place of -p as well\n\n" >&2
+}
+
+pass="${SSH_PASS}"
+timeout=300 # 5 minutes
+wait=10
+
+while getopts "h:p:u:s:t:w:" arg; do
+    case "${arg}" in
+    p) port="${OPTARG}" ;;
+    s) pass="${OPTARG}" ;;
+    t) timeout="${OPTARG}" ;;
+    w) wait="${OPTARG}" ;;
+    h) 
+        usage
+        exit 0
+        ;; 
+    ?)
+        echo "invalid option: -${OPTARG}."
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ -z "$1" ]; then
+    printf "wait-for-hello: missing host\n\n" >&2
+    usage
+    exit 1
+fi 
+
+host="${1}"
+
+ssh_cmd="ssh ${host}" 
+
+if [ -n "$port" ]; then
+    ssh_cmd="${ssh_cmd} -p $port"
+fi
+
+ssh_cmd="${ssh_cmd} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -s netconf"
+
+orig_ssh_cmd=${ssh_cmd}
+
+if [ -n "$pass" ]; then 
+    ssh_cmd="sshpass -p ${pass} ${ssh_cmd}"
+fi
+
+
+printf "wait-for-hello: waiting for netconf subsystem on %s for %d seconds\n" "${host}" "${timeout}" >&2
+
+tries=0
+endtime=$(($(date +%s) + timeout))
+while [ "$(date -u +%s)" -le "$endtime" ]; do
+    echo "${orig_ssh_cmd}"
+    out=$(echo | ${ssh_cmd} | sed 's/]]>]]>//')
+    session_id=$(echo "$out" | xpath -q -e 'hello/session-id/text()')
+
+    if [ -n "$session_id" ]; then
+        printf "wait-for-hello: success! session-id: %d\n" "${session_id}" >&2
+         exit 0
+    fi
+
+    tries=$((tries+1))
+    printf "wait-for-hello: unsucessful waiting %d before trying again\n\n" "${wait}" >&2
+    sleep "$wait"
+done
+
+printf "wait-for-hello: failed to connect to the netconf subsystem after %d seconds (%d tries)\n" "${timeout}" "${tries}" >&2
+exit 1


### PR DESCRIPTION
I ran into some issues where the DUT wasn't coming up in a reasonable
amount of time and essentially a race condition between the integration
tests themselves and the DUT being ready for them.

This adds a quick (ha!) shell script for making sure we are seeing
hello's from the DUT before running the integration tests.
