### PR TITLE
inttest: cleanup image selection.

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -49,6 +49,9 @@ jobs:
           go-version: 1.19
 
       - name: Run containered integration tests
+        env:
+          # Private images for testing
+          CSRX_IMAGE: ghcr.io/nemith/netconf_dut_juniper_csrx:20.3R1.8
         run: | 
          cd inttest
          make inttest

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ There are other RFC around YANG integration that will be looked at later.
 
 See [TODO.md](TODO.md) for a list of what is left to implement these features.
 
-## Differences from [`github.com/juniper/go-netconf/netconf`](https://pkg.go.dev/github.com/Juniper/go-netconf)
+### Differences from [`github.com/juniper/go-netconf/netconf`](https://pkg.go.dev/github.com/Juniper/go-netconf)
 * **Much cleaner, idomatic API, less dumb** I, @nemith, was the original creator of the netconf package and it was my very first Go project and it shows.  There are number of questionable API design, code, and a lot of odd un tested bugs.  Really this rewrite was created to fix this.
 * **No impled vendor ownership** Moving the project out of the `Juniper` organization allowes better control over the project, less implied support (or lack there of), and hopefully more contributions.
 * **Transports are implemented in their own packages.**  This means if you are not using SSH or TLS you don't need to bring in the underlying depdendencies into your binary.
 * **Stream based transports.**  Should mean less memory usage and much less allocation bringing overall performance higher. 
 
-## Differences from [`github.com/scrapli/scrapligo/driver/netconf`](https://pkg.go.dev/github.com/scrapli/scrapligo/driver/netconf)
+### Differences from [`github.com/scrapli/scrapligo/driver/netconf`](https://pkg.go.dev/github.com/scrapli/scrapligo/driver/netconf)
 Scrapligo driver is quite good and way better than the original juniper project.  However this new package concentrates more on RFC correctness and implementing some of the more advanced RFC features like call-home and event notifications.  If there is a desire there could be some callaboration with scrapligo in the future.

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -1,11 +1,21 @@
+.ONESHELL:warning
 .PHONY: all inttest inttest-csrx
 
 .DEFAULT: inttest 
 
 inttest: inttest-csrx
 
+
+# This should warn and exit possibly?
+check-docker-image = \
+	$(if $(shell docker image ls -q $1),, \
+	    $(error docker image $1 is missing))
+
+
+CSRX_IMAGE ?= "csrx:20.3R1.8"
 inttest-csrx:
-	docker-compose -f docker-compose.csrx.yml up \
+	$(call check-docker-image,$(CSRX_IMAGE))
+	CSRX_IMAGE=$(CSRX_IMAGE) docker-compose -f docker-compose.csrx.yml up \
 		--build \
 		--remove-orphans \
 		--abort-on-container-exit \

--- a/inttest/docker-compose.csrx.yml
+++ b/inttest/docker-compose.csrx.yml
@@ -20,7 +20,7 @@ services:
       $$NETCONF_DUT_SSHUSER@$$NETCONF_DUT_SSHHOST &&
       CGO_ENABLED=0 go test -v ."
   csrx:
-    image: ${CSRX_IMAGE:-ghcr.io/nemith/netconf_dut_juniper_csrx:20.3R1.8}
+    image: ${CSRX_IMAGE:?}
     environment:
       - CSRX_JUNOS_CONFIG=/root/initial.conf
     privileged: true


### PR DESCRIPTION
The private image on ghcr.io should really only be used for ci and
instead local testing should default the to the image name provided by
the vendor on import.

Documentation on how to do this will come in the future.
