### PR TITLE
inttest: add netopeer2

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -44,6 +44,7 @@ jobs:
           - ceos
           - csrx
           - confd
+          - netopeer2
     steps:
       - uses: actions/checkout@v3
 

--- a/inttest/Dockerfile.netopeer2
+++ b/inttest/Dockerfile.netopeer2
@@ -1,0 +1,63 @@
+FROM alpine:3.16 as build
+
+RUN apk add --no-cache \
+    bash \
+    cmake \
+    curl \
+    g++ \
+    gcc \ 
+    libc-dev \
+    libssh-dev \
+    linux-pam-dev \
+    make \
+    openssl \
+    openssl-dev \
+    pcre2-dev
+
+WORKDIR /tmp
+
+# Build and install libyang
+RUN curl -Lo libyang-2.0.231.tar.gz https://github.com/CESNET/libyang/archive/refs/tags/v2.0.231.tar.gz 
+RUN tar zxfv libyang-2.0.231.tar.gz
+RUN (cd /tmp/libyang-2.0.231 && \
+     mkdir build && \
+     cd build && \ 
+     cmake .. && \
+     make  && \
+     make install)
+
+# Build and install libnetconf2
+RUN curl -Lo libnetconf2-2.1.18.tar.gz https://github.com/CESNET/libnetconf2/archive/refs/tags/v2.1.18.tar.gz
+RUN tar zxfv libnetconf2-2.1.18.tar.gz
+RUN (cd /tmp/libnetconf2-2.1.18 && \
+     mkdir build && \
+     cd build && \
+     cmake .. && \
+     make && \
+     make install)
+
+# Build and install sysrepo 
+RUN curl -Lo sysrepo-2.1.84.tar.gz https://github.com/sysrepo/sysrepo/archive/refs/tags/v2.1.84.tar.gz
+RUN tar zxfv sysrepo-2.1.84.tar.gz
+RUN (cd /tmp/sysrepo-2.1.84 && \
+     mkdir build && \
+     cd build && \
+     cmake .. && \
+     make && \
+     make install)
+
+# Build and install netopeer2
+RUN curl -Lo netopeer2-2.1.36.tar.gz https://github.com/CESNET/netopeer2/archive/refs/tags/v2.1.36.tar.gz 
+RUN tar zxfv netopeer2-2.1.36.tar.gz
+RUN (cd /tmp/netopeer2-2.1.36 && \
+     mkdir build && \
+     cd build && \
+     cmake .. && \
+     make && \
+     make install)
+
+# add a netconf user with a password
+RUN adduser -D netconf
+RUN echo netconf:netconf | chpasswd
+
+CMD netopeer2-server -d -v2

--- a/inttest/Makefile
+++ b/inttest/Makefile
@@ -34,3 +34,11 @@ confd:
 		--remove-orphans \
 		--abort-on-container-exit \
 		--exit-code-from inttest
+
+netopeer2:
+	docker-compose -f docker-compose.netopeer2.yml up \
+		--build \
+		--remove-orphans \
+		--abort-on-container-exit \
+		--exit-code-from inttest
+   

--- a/inttest/docker-compose.netopeer2.yml
+++ b/inttest/docker-compose.netopeer2.yml
@@ -1,0 +1,24 @@
+version: "3"
+services:
+  inttest:
+    build:
+      context: ..
+      dockerfile: Dockerfile.inttest
+    environment:
+      NETCONF_DUT_SSHHOST: netopeer2
+      NETCONF_DUT_SSHPORT: 830
+      NETCONF_DUT_SSHUSER: netconf
+      NETCONF_DUT_SSHPASS: netconf 
+      NETCONF_DUT_FLAVOR: netopeer2
+    depends_on:
+      - netopeer2
+    command: >
+      sh -c "./wait-for-hello.sh
+      -s $$NETCONF_DUT_SSHPASS
+      -p $$NETCONF_DUT_SSHPORT
+      $$NETCONF_DUT_SSHUSER@$$NETCONF_DUT_SSHHOST &&
+      CGO_ENABLED=0 go test -v ."
+  netopeer2:
+    build:
+      context: .
+      dockerfile: Dockerfile.netopeer2


### PR DESCRIPTION
Adds support for the opensource project netopeer2.  This is the first integration test that can be ran without logins and virtual images from vendors.  It is setup for ssh but it can also support tls and call home and should be a very powerful target for integration testing over the vendors.