### PR TITLE
add error handling and filter to get config requests

### DIFF
--- a/example_ssh_test.go
+++ b/example_ssh_test.go
@@ -37,7 +37,7 @@ func Example_ssh() {
 	// timeout for the call itself.
 	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	deviceConfig, err := session.GetConfig(ctx, "running")
+	deviceConfig, err := session.GetConfig(ctx, "running", "")
 	if err != nil {
 		log.Fatalf("failed to get config: %v", err)
 	}

--- a/example_tls_test.go
+++ b/example_tls_test.go
@@ -67,7 +67,7 @@ func Example_tls() {
 	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	cfg, err := session.GetConfig(ctx, "running")
+	cfg, err := session.GetConfig(ctx, "running", "")
 	if err != nil {
 		panic(err)
 	}

--- a/ops_test.go
+++ b/ops_test.go
@@ -78,7 +78,7 @@ func TestGetConfig(t *testing.T) {
 
 	ts.queueRespString("<rpc-reply xmlns='urn:ietf:params:xml:ns:netconf:base:1.0' message-id='1'><data>foo</data></rpc-reply>")
 
-	got, err := sess.GetConfig(context.Background(), Running)
+	got, err := sess.GetConfig(context.Background(), Running, "")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/session.go
+++ b/session.go
@@ -3,6 +3,7 @@ package netconf
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -298,6 +299,14 @@ func (s *Session) Call(ctx context.Context, op interface{}, resp interface{}) er
 
 	reply, err := s.Do(ctx, msg)
 	if err != nil {
+		return err
+	}
+
+	if len(reply.Errors) > 0 {
+		err := errors.New("rpc call returned errors")
+		for _, v := range reply.Errors {
+			err = errors.Join(err, fmt.Errorf("type: %s, tag: %s, appTag: %s, path: %s, message: %s", v.Type, v.Tag, v.AppTag, v.Path, v.Message))
+		}
 		return err
 	}
 


### PR DESCRIPTION
This adds a very basic error propagation support, so errors could at least be seen. It's pretty basic, but I guess for the alpha version it's better than nothing. Here's example output:
```
2023/02/21 23:34:40 failed to get config: rpc call returned errors
type: protocol, tag: operation-failed, appTag: , path: , message: syntax error
type: protocol, tag: operation-failed, appTag: , path: , message: syntax error
```

The second change is adding filter support to `GetConfig()`. The usage becomes something like this:

`GetConfig()`, without filter:
```xml
<configuration xmlns="http://xml.juniper.net/xnm/1.1/xnm" junos:commit-seconds="1676994552" junos:commit-localtime="2023-02-21 15:49:12 UTC" junos:commit-user="root">
    <version>20200819.234446.1_builder.r1131461</version>
    <system>
        <host-name>csrx-netconf-dut</host-name>
        <root-authentication>
        <junos:comment># juniper123</junos:comment>
            <encrypted-password>$6$dulWt$kKfwWgbSMtvn38k6fJYRVqIaMe6FMfYTMBmIE.oI8a0Z4Xe9Lj5zK/TVWlT140JCNsNbm4A2KHj3UkRWcDtV41</encrypted-password>
        </root-authentication>
        <services>
            <ssh>
                <root-login>allow</root-login>
                <ciphers>aes128-ctr</ciphers>
                <ciphers>aes256-ctr</ciphers>
            </ssh>
            <netconf>
                <junos:comment># This uses normal ssh port 22 and not port 830</junos:comment>
                <ssh>
                </ssh>
            </netconf>
        </services>
    </system>
    <interfaces>
        <interface>
            <name>ge-0/0/0</name>
            <unit>
                <name>0</name>
                <family>
                    <inet>
                        <address>
                            <name>172.19.0.2/24</name>
                        </address>
                    </inet>
                </family>
            </unit>
        </interface>
    </interfaces>
    <security>
        <zones>
            <security-zone>
                <name>test1</name>
                <tcp-rst/>
            </security-zone>
            <security-zone>
                <name>test2</name>
                <tcp-rst/>
            </security-zone>
        </zones>
    </security>
</configuration>
```

`GetConfig()` with filter `security/zones/security-zone/name=test1`:
```xml
<configuration xmlns="http://xml.juniper.net/xnm/1.1/xnm" junos:commit-seconds="1676994552" junos:commit-localtime="2023-02-21 15:49:12 UTC" junos:commit-user="root">
    <security>
        <zones>
            <security-zone>
                <name>test1</name>
                <tcp-rst/>
            </security-zone>
        </zones>
    </security>
</configuration>
```

`GetConfig()` with filter `security/zones/security-zone` (without selector):
```xml
<configuration xmlns="http://xml.juniper.net/xnm/1.1/xnm" junos:commit-seconds="1676994552" junos:commit-localtime="2023-02-21 15:49:12 UTC" junos:commit-user="root">
    <security>
        <zones>
            <security-zone>
                <name>petko-bika</name>
                <tcp-rst/>
                <enable-reverse-reroute/>
            </security-zone>
            <security-zone>
                <name>test1</name>
                <tcp-rst/>
            </security-zone>
            <security-zone>
                <name>test2</name>
                <tcp-rst/>
            </security-zone>
        </zones>
    </security>
</configuration>
```

Trailing `/` are ignored in the filter as are empty paths, for example `this/filter/here` is the same as `this//filter/here/`.