### PR TITLE
basic callhome functionality

### DIFF
--- a/callhome.go
+++ b/callhome.go
@@ -1,0 +1,157 @@
+package netconf
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/nemith/netconf/transport"
+	ncssh "github.com/nemith/netconf/transport/ssh"
+	nctls "github.com/nemith/netconf/transport/tls"
+	"golang.org/x/crypto/ssh"
+	"net"
+)
+
+type TransportType uint
+
+const (
+	TransportTypeSSH TransportType = iota
+	TransportTypeTLS
+)
+
+/*
+CallHome implements netconf callhome procedure as specified in RFC 8071
+*/
+type CallHome struct {
+	listener  net.Listener
+	network   string
+	addr      string
+	transport TransportType
+	configSSH *ssh.ClientConfig
+	configTLS *tls.Config
+	session   *Session
+}
+
+type CallHomeOption func(*CallHome)
+
+// WithAddress sets the address (as required by net.Listen) the CallHome server listen to
+func WithAddress(addr string) CallHomeOption {
+	return func(ch *CallHome) {
+		ch.addr = addr
+	}
+}
+
+// WithNetwork set the network (as required by net.Listen) the CallHome server listen to
+func WithNetwork(network string) CallHomeOption {
+	return func(ch *CallHome) {
+		ch.network = network
+	}
+}
+
+// WithTransport sets the transport type used by the CallHome server
+func WithTransport(t TransportType) CallHomeOption {
+	return func(ch *CallHome) {
+		ch.transport = t
+	}
+}
+
+// WithConfigSSH sets the ssh.ClientConfig used by the CallHome server to upgrade incoming connections
+func WithConfigSSH(sc *ssh.ClientConfig) CallHomeOption {
+	return func(ch *CallHome) {
+		ch.configSSH = sc
+	}
+}
+
+// WithConfigTLS sets the tls.Config used by the CallHome server to upgrade incoming connections
+func WithConfigTLS(tc *tls.Config) CallHomeOption {
+	return func(ch *CallHome) {
+		ch.configTLS = tc
+	}
+}
+
+// NewCallHome creates a CallHome client
+func NewCallHome(opts ...CallHomeOption) (*CallHome, error) {
+	const (
+		defaultAddress   = "0.0.0.0:4334"
+		defaultNetwork   = "tcp"
+		defaultTransport = TransportTypeSSH
+	)
+
+	ch := &CallHome{
+		addr:      defaultAddress,
+		network:   defaultNetwork,
+		transport: defaultTransport,
+	}
+
+	for _, opt := range opts {
+		opt(ch)
+	}
+
+	if ch.configTLS == nil && ch.configSSH == nil {
+		return nil, fmt.Errorf("one of TLS or SSH configuration must be specified, depending on selected transport")
+	}
+
+	if ch.network != "tcp" && ch.network != "tcp4" && ch.network != "tcp6" {
+		return nil, fmt.Errorf("invalid network, must be one of: tcp, tcp4, tcp6")
+	}
+
+	return ch, nil
+}
+
+// Listen waits for incoming callhome connections
+// NOTE: only handles one connection at a time
+func (ch *CallHome) Listen() error {
+	ln, err := net.Listen(ch.network, ch.addr)
+	if err != nil {
+		return err
+	}
+	ch.listener = ln
+	defer func() {
+		_ = ch.Close()
+	}()
+
+	conn, err := ch.listener.Accept()
+	if err != nil {
+		return err
+	}
+	err = ch.handleConnection(conn)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// handleConnection upgrade input net.Conn to establish a netconf session
+func (ch *CallHome) handleConnection(conn net.Conn) error {
+	var t transport.Transport
+	var err error
+	// TODO: Missing certificates validation as specified in rfc8071 3.1
+	switch ch.transport {
+	case TransportTypeSSH:
+		t, err = ncssh.DialWithConn(conn.RemoteAddr().String(), ch.configSSH, conn)
+		if err != nil {
+			return err
+		}
+	case TransportTypeTLS:
+		t, err = nctls.DialWithConn(ch.configTLS, conn)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid transport type")
+	}
+	s, err := Open(t)
+	if err != nil {
+		return err
+	}
+	ch.session = s
+	return nil
+}
+
+// Session gets the callhome netconf session
+func (ch *CallHome) Session() *Session {
+	return ch.session
+}
+
+// Close terminates the callhome server connection
+func (ch *CallHome) Close() error {
+	return ch.listener.Close()
+}

--- a/examples/callhome_ssh/callhome_ssh.go
+++ b/examples/callhome_ssh/callhome_ssh.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"github.com/nemith/netconf"
+	"golang.org/x/crypto/ssh"
+	"log"
+	"time"
+)
+
+func main() {
+	config := &ssh.ClientConfig{
+		User: "admin",
+		Auth: []ssh.AuthMethod{
+			ssh.Password("secret"),
+		},
+		// as specified in rfc8071 3.1 C5 netconf client must validate host keys
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	addr := "0.0.0.0:4334"
+	ch, err := netconf.NewCallHome(netconf.WithConfigSSH(config), netconf.WithAddress(addr))
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("callhome server listening on: %s", addr)
+	err = ch.Listen()
+	if err != nil {
+		panic(err)
+	}
+	session := ch.Session()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	deviceConfig, err := session.GetConfig(ctx, "running")
+	if err != nil {
+		log.Fatalf("failed to get config: %v", err)
+	}
+
+	log.Printf("Config:\n%s\n", deviceConfig)
+
+	if err := session.Close(context.Background()); err != nil {
+		log.Print(err)
+	}
+}

--- a/transport/ssh/ssh.go
+++ b/transport/ssh/ssh.go
@@ -46,6 +46,16 @@ func Dial(ctx context.Context, network, addr string, config *ssh.ClientConfig) (
 	return newTransport(client, true)
 }
 
+// DialWithConn is same as Dial but creates the transport on top of input net.Conn
+func DialWithConn(addr string, config *ssh.ClientConfig, conn net.Conn) (*Transport, error) {
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		return nil, err
+	}
+	client := ssh.NewClient(sshConn, chans, reqs)
+	return newTransport(client, true)
+}
+
 // NewTransport will create a new ssh transport as defined in RFC6242 for use
 // with netconf.  Unlike Dial, the underlying client will not be automatically
 // closed when the transport is closed (however any sessions and subsystems
@@ -84,8 +94,8 @@ func newTransport(client *ssh.Client, owned bool) (*Transport, error) {
 	}, nil
 }
 
-// Close will close the underlying transport.  If the connection was created
-// with Dial then then underlying ssh.Client is closed as well.  If not only
+// Close will close the underlying transport. If the connection was created
+// with Dial then underlying ssh.Client is closed as well.  If not only
 // the sessions is closed.
 func (t *Transport) Close() error {
 	if err := t.sess.Close(); err != nil {

--- a/transport/tls/tls.go
+++ b/transport/tls/tls.go
@@ -30,6 +30,12 @@ func Dial(ctx context.Context, network, addr string, config *tls.Config) (*Trans
 
 }
 
+// DialWithConn is same as Dial but creates the transport on top of input net.Conn
+func DialWithConn(config *tls.Config, conn net.Conn) (*Transport, error) {
+	tlsConn := tls.Client(conn, config)
+	return NewTransport(tlsConn), nil
+}
+
 // NewTransport takes an already connected tls transport and returns a new
 // Transport.
 func NewTransport(conn *tls.Conn) *Transport {


### PR DESCRIPTION
This a super basic callhome functionality based on rfc8071. Tested with real netconf device (in SSH mode), didn't test with TLS.

Opening as a DRAFT, if it is something you may be interested in maybe we can have some discussion on how to proceed further.