### PR TITLE
improve `RPCMsg` xml encoding testing 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "cSpell.words": ["netconf"]
+  "cSpell.words": [
+    "byteslice",
+    "innerxml",
+    "inttest",
+    "Junos",
+    "nemith",
+    "netconf"
+  ]
 }

--- a/inttest/ssh_test.go
+++ b/inttest/ssh_test.go
@@ -137,7 +137,8 @@ func TestJunosCommand(t *testing.T) {
 	session := setupSSH(t)
 
 	cmd := struct {
-		Command string `xml:"command"`
+		XMLName xml.Name `xml:"command"`
+		Command string   `xml:",innerxml"`
 	}{
 		Command: "show version",
 	}

--- a/inttest/ssh_test.go
+++ b/inttest/ssh_test.go
@@ -143,13 +143,7 @@ func TestJunosCommand(t *testing.T) {
 		Command: "show version",
 	}
 
-	b, err := xml.Marshal(&cmd)
-	if err != nil {
-		panic(err)
-	}
-	panic(b)
-
 	ctx := context.Background()
-	err = session.Call(ctx, &cmd, nil)
+	err := session.Call(ctx, &cmd, nil)
 	assert.NoError(t, err)
 }

--- a/msg.go
+++ b/msg.go
@@ -26,21 +26,11 @@ func (msg *RPCMsg) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		return fmt.Errorf("operation cannot be nil")
 	}
 
+	// TODO: validate operation is named?
+
 	// alias the type to not cause recursion calling e.Encode
 	type rpcMsg RPCMsg
 	inner := rpcMsg(*msg)
-
-	switch msg.Operation.(type) {
-	case string, []byte:
-		break
-	default:
-		var err error
-		inner.Operation, err = xml.Marshal(&msg.Operation)
-		if err != nil {
-			return err
-		}
-	}
-
 	return e.Encode(&inner)
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -1,0 +1,66 @@
+package netconf
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalRPCMsg(t *testing.T) {
+	tt := []struct {
+		name      string
+		operation interface{}
+		err       bool
+		want      []byte
+	}{
+		{
+			name:      "nil",
+			operation: nil,
+			err:       true,
+		},
+		{
+			name:      "string",
+			operation: "<foo><bar/></foo>",
+			want:      []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><foo><bar/></foo></rpc>`),
+		},
+		{
+			name:      "byteslice",
+			operation: []byte("<baz><qux/></baz>"),
+			want:      []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><baz><qux/></baz></rpc>`),
+		},
+		{
+			name:      "validate",
+			operation: validateReq{Source: Running},
+			want:      []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><validate><source><running/></source></validate></rpc>`),
+		},
+		{
+			name: "customStruct",
+			operation: struct {
+				XMLName xml.Name `xml:"http://xml.juniper.net/junos/22.4R0/junos command"`
+				Command string   `xml:",innerxml"`
+			}{
+				Command: "show bgp neighbors",
+			},
+			want: []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><command xmlns="http://xml.juniper.net/junos/22.4R0/junos">show bgp neighbors</command></rpc>`),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := xml.Marshal(&RPCMsg{
+				MessageID: 1,
+				Operation: tc.operation,
+			})
+			t.Logf("out: %s", out)
+
+			if tc.err {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, out, tc.want)
+		})
+	}
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -35,7 +35,7 @@ func TestMarshalRPCMsg(t *testing.T) {
 			want:      []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><validate><source><running/></source></validate></rpc>`),
 		},
 		{
-			name: "customStruct",
+			name: "namedStruct",
 			operation: struct {
 				XMLName xml.Name `xml:"http://xml.juniper.net/junos/22.4R0/junos command"`
 				Command string   `xml:",innerxml"`
@@ -44,6 +44,15 @@ func TestMarshalRPCMsg(t *testing.T) {
 			},
 			want: []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><command xmlns="http://xml.juniper.net/junos/22.4R0/junos">show bgp neighbors</command></rpc>`),
 		},
+		/*
+			{
+				name: "unnamedStruct",
+				operation: struct {
+					Command string `xml:"command"`
+				}{
+					Command: "show version",
+				},
+			},*/
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Add unittest for RPCMsg encoding and ensure that operation is supplied when encoding `rpc` request messages (i.e `ReqMSG`) via custom MarshalXML method.

Future work to make sure structs passed in are named.

**Test Plan:**
```
$ go test . -v -run=MarshalRPCMsg
=== RUN   TestMarshalRPCMsg
=== RUN   TestMarshalRPCMsg/nil
    msg_test.go:55: out: 
=== RUN   TestMarshalRPCMsg/string
    msg_test.go:55: out: <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><foo><bar/></foo></rpc>
=== RUN   TestMarshalRPCMsg/byteslice
    msg_test.go:55: out: <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><baz><qux/></baz></rpc>
=== RUN   TestMarshalRPCMsg/validate
    msg_test.go:55: out: <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><validate><source><running/></source></validate></rpc>
=== RUN   TestMarshalRPCMsg/customStruct
    msg_test.go:55: out: <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><command xmlns="http://xml.juniper.net/junos/22.4R0/junos">show bgp neighbors</command></rpc>
--- PASS: TestMarshalRPCMsg (0.00s)
    --- PASS: TestMarshalRPCMsg/nil (0.00s)
    --- PASS: TestMarshalRPCMsg/string (0.00s)
    --- PASS: TestMarshalRPCMsg/byteslice (0.00s)
    --- PASS: TestMarshalRPCMsg/validate (0.00s)
    --- PASS: TestMarshalRPCMsg/customStruct (0.00s)
PASS
ok      github.com/nemith/netconf       (cached)
```



