### PR TITLE
improve rpc error handling

### DIFF
--- a/inttest/ssh_test.go
+++ b/inttest/ssh_test.go
@@ -127,9 +127,8 @@ func TestBadGetConfig(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := session.GetConfig(ctx, "non-exist")
 	assert.Nil(t, cfg)
-	var rpcErrors netconf.RPCErrors
-	assert.ErrorAs(t, err, &rpcErrors)
-	assert.Len(t, rpcErrors, 1)
+	var rpcErr netconf.RPCError
+	assert.ErrorAs(t, err, &rpcErr)
 }
 
 func TestJunosCommand(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -301,16 +301,21 @@ func (s *Session) Call(ctx context.Context, op interface{}, resp interface{}) er
 		return err
 	}
 
+	// return rpc errors if we have them
+	switch {
+	case len(reply.Errors) == 1:
+		return reply.Errors[0]
+	case len(reply.Errors) > 1:
+		return reply.Errors
+	}
+
+	// unmarshal the body
 	if resp != nil {
-		err = xml.Unmarshal(reply.Data, resp)
+		if err = xml.Unmarshal(reply.Body, resp); err != nil {
+			return err
+		}
 	}
-
-	// if we have RPC errors return them
-	if reply.Errors != nil {
-		err = reply.Errors
-	}
-
-	return err
+	return nil
 }
 
 // Close will gracefully close the sessions first by sending a `close-session`


### PR DESCRIPTION
Error handling and RPCReplyMsg have been a bit of an after thought.  This follows the RPC more closely and adds unit tests.