### PR TITLE
transport: advance the frame on close not on next msg

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -20,7 +20,7 @@ func newTestServer(t *testing.T) *testServer {
 	}
 }
 
-func (s *testServer) handle(r io.Reader, w io.WriteCloser) {
+func (s *testServer) handle(r io.ReadCloser, w io.WriteCloser) {
 	in, err := io.ReadAll(r)
 	if err != nil {
 		panic(fmt.Sprintf("testerver: failed to read incomming message: %v", err))
@@ -62,19 +62,19 @@ func (s *testServer) popReqString() (string, error) {
 func (s *testServer) transport() *testTransport { return newTestTransport(s.handle) }
 
 type testTransport struct {
-	handler func(r io.Reader, w io.WriteCloser)
-	out     chan io.Reader
+	handler func(r io.ReadCloser, w io.WriteCloser)
+	out     chan io.ReadCloser
 	// msgReceived, msgSent int
 }
 
-func newTestTransport(handler func(r io.Reader, w io.WriteCloser)) *testTransport {
+func newTestTransport(handler func(r io.ReadCloser, w io.WriteCloser)) *testTransport {
 	return &testTransport{
 		handler: handler,
-		out:     make(chan io.Reader),
+		out:     make(chan io.ReadCloser),
 	}
 }
 
-func (s *testTransport) MsgReader() (io.Reader, error) {
+func (s *testTransport) MsgReader() (io.ReadCloser, error) {
 	return <-s.out, nil
 }
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -23,7 +23,7 @@ type Transport interface {
 	// MsgReader returns a new io.Reader to read a single netconf message. There
 	// can only be a single reader for a transport at a time.  Obtaining a new
 	// reader should advance the stream to the start of the next message.`
-	MsgReader() (io.Reader, error)
+	MsgReader() (io.ReadCloser, error)
 
 	// MsgWriter returns a new io.WriteCloser to write a single netconf message.
 	// After writing a message the writer must be closed. Implementers should


### PR DESCRIPTION
Because we are using streaming to read xml from the wire using MsgReader we may not read the end of frame headers (i.e after XML is happy it's consumed enough from the input).  To get around this there was an `adavance()` call added to the frame protocols (`eomReader`, `chunkReader`) that would make sure we would advance to the start of the next frame.  This `advance` function was only called when obtaining the a newReader and not after we were done reading a netconf message.

This potentially could lead to situations where the remote side is still trying to write the end of a frame but we have already given up on it and closed the session.  This shouldn't matter, but bad netconf servers may not handle this right and it logically doesn't make sense.  We should read an entire frame and not just enough of the "interesting parts".|

This migrates the `MsgReader` from returning `io.Reader` to and `io.ReaderCloser` to explicitly close (and thus advance the frame) after the `recv()` loop has received it. 

