### PR TITLE
new `session.Do` API

### DIFF
--- a/inttest/ssh_test.go
+++ b/inttest/ssh_test.go
@@ -131,6 +131,7 @@ func TestJunosCommand(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err := session.Call(ctx, &cmd, nil)
+	reply, err := session.Do(ctx, &cmd)
 	assert.NoError(t, err)
+	assert.NoError(t, reply.Err())
 }

--- a/msg_test.go
+++ b/msg_test.go
@@ -65,12 +65,12 @@ func TestRawXMLMarshal(t *testing.T) {
 var helloMsgTestTable = []struct {
 	name string
 	raw  []byte
-	msg  HelloMsg
+	msg  helloMsg
 }{
 	{
 		name: "basic",
 		raw:  []byte(`<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><capabilities><capability>urn:ietf:params:netconf:base:1.0</capability><capability>urn:ietf:params:netconf:base:1.1</capability></capabilities></hello>`),
-		msg: HelloMsg{
+		msg: helloMsg{
 			XMLName: xml.Name{
 				Local: "hello",
 				Space: "urn:ietf:params:xml:ns:netconf:base:1.0",
@@ -100,7 +100,7 @@ var helloMsgTestTable = []struct {
   </capabilities>
   <session-id>410</session-id>
 </hello>`),
-		msg: HelloMsg{
+		msg: helloMsg{
 			XMLName: xml.Name{
 				Local: "hello",
 				Space: "urn:ietf:params:xml:ns:netconf:base:1.0",
@@ -127,7 +127,7 @@ var helloMsgTestTable = []struct {
 func TestUnmarshalHelloMsg(t *testing.T) {
 	for _, tc := range helloMsgTestTable {
 		t.Run(tc.name, func(t *testing.T) {
-			var got HelloMsg
+			var got helloMsg
 			err := xml.Unmarshal(tc.raw, &got)
 			assert.NoError(t, err)
 			assert.Equal(t, got, tc.msg)
@@ -168,7 +168,7 @@ func TestMarshalRPCMsg(t *testing.T) {
 		},
 		{
 			name:      "validate",
-			operation: validateReq{Source: Running},
+			operation: ValidateReq{Source: Running},
 			want:      []byte(`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><validate><source><running/></source></validate></rpc>`),
 		},
 		{
@@ -194,7 +194,7 @@ func TestMarshalRPCMsg(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := xml.Marshal(&RPCMsg{
+			out, err := xml.Marshal(&request{
 				MessageID: 1,
 				Operation: tc.operation,
 			})
@@ -229,12 +229,12 @@ func TestUnmarshalRPCReply(t *testing.T) {
 	tt := []struct {
 		name  string
 		reply []byte
-		want  RPCReplyMsg
+		want  Reply
 	}{
 		{
 			name:  "error",
 			reply: replyJunosGetConfigError,
-			want: RPCReplyMsg{
+			want: Reply{
 				XMLName: xml.Name{
 					Space: "urn:ietf:params:xml:ns:netconf:base:1.0",
 					Local: "rpc-reply",
@@ -268,7 +268,7 @@ func TestUnmarshalRPCReply(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			var got RPCReplyMsg
+			var got Reply
 			err := xml.Unmarshal(tc.reply, &got)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.want, got)


### PR DESCRIPTION
This refactors the `Do` and it's `Reply` object. 

`Do` no longer takes a `RPCMsg` as the only field that isn't overwritten is the request itself.  So instead it just take a request.  

`Reply` struct as been renamed from `RPCReplyMsg` to just `Reply` to make it a more friendly "first class" object.  Methods have been added to it to make it more friendly as well:
 
 * `Decode` method wraps `xml.Unmarshal` for decoding the body
 * `Err` was added to return the rpc-errors with the severity of `error` (not `warning`) as Go errors. 
 
 This prompted some other cleanup:
 
 * `NotificationMsg` -> ` Notification`
 * `RPCMsg` was unexported as there really shouldn't be anything that a user need to use directly.
 * The RFC operations msg types were all unexported so they can be used with `Do` directly if wanted. 
 * HelloMsg was unexported.
 
 This is a breaking change, but we are not 1.0 yet. 