### PR TITLE
allow more control of filtering Reply errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	golang.org/x/sys v0.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
+golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
+golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.11.0 h1:F9tnn/DA/Im8nCwm+fX+1/eBwi4qFjRT++MhtVC4ZX0=

--- a/msg_test.go
+++ b/msg_test.go
@@ -244,7 +244,7 @@ func TestUnmarshalRPCReply(t *testing.T) {
 					{
 						Type:     ErrTypeProtocol,
 						Tag:      ErrOperationFailed,
-						Severity: ErrSevError,
+						Severity: SevError,
 						Message:  "syntax error, expecting <candidate/> or <running/>",
 						Info: []byte(`
 <bad-element>non-exist</bad-element>


### PR DESCRIPTION
The `Reply.Err()` and `RPCErrors.Filter()` are useful functions to get the `SevError` level errors out, but some people may want to treat `SevWarning` as errors as well and doing it manually is a pain.

As not to add a bunch of alternative functions like `RPCError.FilterWarn`, `Reply.ErrWarn()` and `Reply.ErrAll()` this updates `Filter` and `Err` to take in a list of desired severity levels.  If they are missing they go back to defaulting to `SevError` which is a sane default.

## Breaking change:

The API for `reply.Err()` and `RPCErrors.Filter()` were changed as above. For most call sites this should be fine but anyone using this function in a interface or explicitly using it as a type will break.
`ErrSevError` was renamed to `SevError`
`ErrSevWarning` was reanmed to `SevWarning`

As the API is not yet stable these changes are ok and will become stabilized after 1.0.0