### PR TITLE
bump for Go version 1.21 and 1.22

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - run: go test -coverprofile=cover.out ./...
 
       - name: checkout covrage branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'coverage'
           path: coverage

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,8 +11,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: extractions/setup-just@v1
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
       - run: just lint
 
   test:
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.21", "1.22"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: extractions/setup-just@v1
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
       - run: GO_VERSION=${{ matrix.go }} just test
 
   inttest:
@@ -39,15 +39,15 @@ jobs:
           - confd
           - netopeer2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@v2
 
       - name: Run containered integration tests
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go `netconf` client library
 
-WARNING: This is currently alpha quality.  The API isn't solid yet and a lot of testing still needs to be done as well as additional feaures.  Working for a solid beta API is incoming.
+WARNING: This is still pre-1.0 and the API may still change however this library is being use at scale in production with good results.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/nemith/netconf.svg)](https://pkg.go.dev/github.com/nemith/netconf)
 [![Report Card](https://goreportcard.com/badge/github.com/nemith/netconf)](https://goreportcard.com/report/github.com/nemith/netconf)
@@ -10,7 +10,7 @@ WARNING: This is currently alpha quality.  The API isn't solid yet and a lot of 
 
 This library is used to create client applications for connecting to network devices via NETCONF.
 
-Like Go itself, only the latest two Go versions are tested and supported (Go 1.19 or Go 1.20).
+Like Go itself, only the latest two Go versions are tested and supported (Go 1.22 or Go 1.21).
 
 
 ## RFC Support

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nemith/netconf
 
-go 1.19
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
Update for the last two Go versions as per README