### PR TITLE
Create CallWrap() for multi root XML

### DIFF
--- a/session.go
+++ b/session.go
@@ -1,6 +1,7 @@
 package netconf
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"errors"
@@ -347,6 +348,29 @@ func (s *Session) Call(ctx context.Context, req any, resp any) error {
 	if err := reply.Err(); err != nil {
 		return err
 	}
+
+	if err := reply.Decode(&resp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Session) CallWrap(ctx context.Context, req any, resp any) error {
+	reply, err := s.Do(ctx, &req)
+	if err != nil {
+		return err
+	}
+
+	if err := reply.Err(); err != nil {
+		return err
+	}
+
+	reply.Body = bytes.Join([][]byte{
+		[]byte("<wrap>"),
+		reply.Body,
+		[]byte("</wrap>"),
+	}, nil)
 
 	if err := reply.Decode(&resp); err != nil {
 		return err


### PR DESCRIPTION
In case the NETCONF server returns a multi-root XML in its body we are currently unable to access them, only the first one is unmarshaled and returned to the caller.

Wrap all the body's roots into a XML tag that will become the only one body's root. This will allow the caller to recover all the body's root of the NETCONF reply.