### PR TITLE
chore(transport/ssh): Increase test coverage (+bug fixes)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@ linters:
   enable:
     - errorlint
   settings:
-    errcheck:
-      check-type-assertions: true
-      check-blank: true
     errorlint:
       errorf: true
       asserts: true


### PR DESCRIPTION
The original transport/ssh tests were limited.  This expands the test coverage to more coverage.  In the process a couple bugs were found and fixed.

- When calling newTransport fails we are responsible for closing the connection 
- Fixed extra call to Close()

```
❯ go test ./transport/ssh -cover 
ok      nemith.io/netconf/transport/ssh 0.683s  coverage: 82.2% of statements
``` 