### PR TITLE
feat: Make CapabilitySet public

### DIFF
--- a/inttest/ssh_test.go
+++ b/inttest/ssh_test.go
@@ -92,7 +92,7 @@ func setupSSH(t *testing.T) *netconf.Session {
 func TestSSHOpen(t *testing.T) {
 	session := setupSSH(t)
 	assert.NotZero(t, session.SessionID())
-	assert.NotEmpty(t, session.ServerCapabilities())
+	assert.NotZero(t, session.ServerCaps().Len())
 	err := session.Close(context.Background())
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
CapabilitySet was a unexported before with the public api being a `[]string`.  This exports it and has the session return the `CapabilitySet` instead of `[]string` exposing the `Has()` method .

Right now this is a completely frozen/readonly interface which feels right.  